### PR TITLE
Python 3 compatibility

### DIFF
--- a/examples/notch_port_example.py
+++ b/examples/notch_port_example.py
@@ -5,8 +5,8 @@ from resonator_tools import circuit
 port1 = circuit.notch_port()
 port1.add_froms2p('S21testdata.s2p',3,4,'realimag',fdata_unit=1e9,delimiter=None)
 port1.autofit()
-print "Fit results:", port1.fitresults
+print("Fit results:", port1.fitresults)
 port1.plotall()
-print "single photon limit:", port1.get_single_photon_limit(diacorr=True), "dBm"
-print "photons in reso for input -140dBm:", port1.get_photons_in_resonator(-140,unit='dBm',diacorr=True), "photons"
-print "done"
+print("single photon limit:", port1.get_single_photon_limit(diacorr=True), "dBm")
+print("photons in reso for input -140dBm:", port1.get_photons_in_resonator(-140,unit='dBm',diacorr=True), "photons")
+print("done")

--- a/examples/notch_port_example_withGUI.py
+++ b/examples/notch_port_example_withGUI.py
@@ -5,8 +5,8 @@ from resonator_tools import circuit
 port1 = circuit.notch_port()
 port1.add_froms2p('S21testdata.s2p',3,4,'realimag',fdata_unit=1e9,delimiter=None)
 port1.GUIfit()
-print "Fit results:", port1.fitresults
+print("Fit results:", port1.fitresults)
 port1.plotall()
-print "single photon limit:", port1.get_single_photon_limit(diacorr=True), "dBm"
-print "photons in reso for input -140dBm:", port1.get_photons_in_resonator(-140,unit='dBm',diacorr=True), "photons"
-print "done"
+print("single photon limit:", port1.get_single_photon_limit(diacorr=True), "dBm")
+print("photons in reso for input -140dBm:", port1.get_photons_in_resonator(-140,unit='dBm',diacorr=True), "photons")
+print("done")

--- a/examples/reflection_port_example.py
+++ b/examples/reflection_port_example.py
@@ -5,7 +5,7 @@ from resonator_tools import circuit
 port1 = circuit.reflection_port()
 port1.add_fromtxt('S11.txt','dBmagphasedeg',1)
 port1.autofit()
-print "Fit results:", port1.fitresults
+print("Fit results:", port1.fitresults)
 port1.plotall()
-print "single photon limit:", port1.get_single_photon_limit(), "dBm"
-print "done"
+print("single photon limit:", port1.get_single_photon_limit(), "dBm")
+print("done")

--- a/examples/reflection_port_example_withGUI.py
+++ b/examples/reflection_port_example_withGUI.py
@@ -5,7 +5,7 @@ from resonator_tools import circuit
 port1 = circuit.reflection_port()
 port1.add_fromtxt('S11.txt','dBmagphasedeg',1)
 port1.GUIfit()
-print "Fit results:", port1.fitresults
+print("Fit results:", port1.fitresults)
 port1.plotall()
-print "single photon limit:", port1.get_single_photon_limit(), "dBm"
-print "done"
+print("single photon limit:", port1.get_single_photon_limit(), "dBm")
+print("done")

--- a/examples/remove_wiggly_baseline_with GUI.py
+++ b/examples/remove_wiggly_baseline_with GUI.py
@@ -26,8 +26,8 @@ port1.GUIbaselinefit()
 
 # fit the corrected data
 port1.GUIfit()
-print "Fit results:", port1.fitresults
+print("Fit results:", port1.fitresults)
 port1.plotall()
-print "single photon limit:", port1.get_single_photon_limit(), "dBm"
-print "done"
+print("single photon limit:", port1.get_single_photon_limit(), "dBm")
+print("done")
 

--- a/resonator_tools/calibration.py
+++ b/resonator_tools/calibration.py
@@ -31,7 +31,7 @@ class calibration(object):
 		L = len(y)
 		D = sparse.csc_matrix(np.diff(np.eye(L), 2))
 		w = np.ones(L)
-		for i in xrange(niter):
+		for i in range(niter):
 			W = sparse.spdiags(w, 0, L, L)
 			Z = W + lam * D.dot(D.transpose())
 			z = sparse.linalg.spsolve(Z, w*y)

--- a/resonator_tools/circlefit.py
+++ b/resonator_tools/circlefit.py
@@ -98,7 +98,7 @@ class circlefit(object):
         try:
             popt, pcov = spopt.curve_fit(fitfunc, np.array(f_data), np.array(amplitude_sqr),p0=p0)
         #A1, A2, A3, A4, fr, Ql = p_final[0]
-        #print p_final[0][5]
+        #print(p_final[0][5])
             if pcov is not None:
                 self.df_error = np.sqrt(pcov[4][4])
                 self.dQl_error = np.sqrt(pcov[5][5])
@@ -164,10 +164,10 @@ class circlefit(object):
         # the term *sqrt term corrects for the constraint, because it may be altered due to numerical inaccuracies during calculation
         r0 = 1./(2.*np.absolute(A_vec[0]))*np.sqrt(A_vec[1]*A_vec[1]+A_vec[2]*A_vec[2]-4.*A_vec[0]*A_vec[3])
         if refine_results:
-            print "agebraic r0: " + str(r0)
+            print("agebraic r0: " + str(r0))
             xc,yc,r0 = self._fit_circle_iter(z_data, xc, yc, r0)
             r0 = self._fit_circle_iter_radialweight(z_data, xc, yc, r0)
-            print "iterative r0: " + str(r0)
+            print("iterative r0: " + str(r0))
         return xc, yc, r0
 
     def _guess_delay(self,f_data,z_data):
@@ -305,35 +305,35 @@ class circlefit(object):
     
     def _residuals_notch_ideal(self,p,x,y):
         fr,absQc,Ql,phi0 = p
-        #if fr == 0: print p
+        #if fr == 0: print(p)
         err = np.absolute( y - (  ( 1. - (Ql/float(absQc)*np.exp(1j*phi0))/(1+2j*Ql*(x-fr)/float(fr)) )  ) )
         #if np.isinf((np.complex(1,2*Ql*(x-fr)/float(fr))).imag):
-         #   print np.complex(1,2*Ql*(x-fr)/float(fr))
-          #  print "x: " + str(x)
-           # print "Ql: " +str(Ql)
-            #print "fr: " +str(fr)
+         #   print(np.complex(1,2*Ql*(x-fr)/float(fr)))
+          #  print("x: " + str(x))
+           # print("Ql: " +str(Ql))
+            #print("fr: " +str(fr))
         return err
     
     def _residuals_notch_ideal_complex(self,p,x,y):
         fr,absQc,Ql,phi0 = p
-        #if fr == 0: print p
+        #if fr == 0: print(p)
         err = y - (  ( 1. - (Ql/float(absQc)*np.exp(1j*phi0))/(1+2j*Ql*(x-fr)/float(fr)) )  )
         #if np.isinf((np.complex(1,2*Ql*(x-fr)/float(fr))).imag):
-         #   print np.complex(1,2*Ql*(x-fr)/float(fr))
-          #  print "x: " + str(x)
-           # print "Ql: " +str(Ql)
-            #print "fr: " +str(fr)
+         #   print(np.complex(1,2*Ql*(x-fr)/float(fr)))
+          #  print("x: " + str(x))
+           # print("Ql: " +str(Ql))
+            #print("fr: " +str(fr))
         return err
         
     def _residuals_directrefl(self,p,x,y):
         fr,Qc,Ql = p
-        #if fr == 0: print p
+        #if fr == 0: print(p)
         err = y - ( 2.*Ql/Qc - 1. + 2j*Ql*(fr-x)/fr ) / ( 1. - 2j*Ql*(fr-x)/fr )
         #if np.isinf((np.complex(1,2*Ql*(x-fr)/float(fr))).imag):
-         #   print np.complex(1,2*Ql*(x-fr)/float(fr))
-          #  print "x: " + str(x)
-           # print "Ql: " +str(Ql)
-            #print "fr: " +str(fr)
+         #   print(np.complex(1,2*Ql*(x-fr)/float(fr)))
+          #  print("x: " + str(x))
+           # print("Ql: " +str(Ql))
+            #print("fr: " +str(fr))
         return err
     
     def _residuals_transm_ideal(self,p,x,y):

--- a/resonator_tools/circuit.py
+++ b/resonator_tools/circuit.py
@@ -52,7 +52,7 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 		z_data = z_data/maxval
 		A1, A2, A3, A4, fr, Ql = self._fit_skewed_lorentzian(f_data,z_data)
 		if self.df_error/fr > 0.0001 or self.dQl_error/Ql>0.1:
-			#print "WARNING: Calibration using Lorentz fit failed, trying phase fit..."
+			#print("WARNING: Calibration using Lorentz fit failed, trying phase fit...")
 			A1 = np.mean(np.absolute(z_data))
 			A2 = 0.
 			A3 = 0.
@@ -65,10 +65,10 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 			A2 = 0.
 		else:
 			A2 = 0.
-			print "WARNING: The ignoreslope option is ignored! Corrections to the baseline should be done manually prior to fitting."
-			print "see also: resonator_tools.calibration.fit_baseline_amp() etc. for help on fitting the baseline."
-			print "There is also an example ipython notebook for using this function."
-			print "However, make sure to understand the impact of the baseline (parasitic coupled resonances etc.) on your system."
+			print("WARNING: The ignoreslope option is ignored! Corrections to the baseline should be done manually prior to fitting.")
+			print("see also: resonator_tools.calibration.fit_baseline_amp() etc. for help on fitting the baseline.")
+			print("There is also an example ipython notebook for using this function.")
+			print("However, make sure to understand the impact of the baseline (parasitic coupled resonances etc.) on your system.")
 			#z_data = (np.absolute(z_data)-A2*(f_data-fr)) * np.exp(np.angle(z_data)*1j)  #usually not necessary
 		if delay is None:
 			if guess==True:
@@ -115,7 +115,7 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 		theta0 = self._periodic_boundary(phi0+np.pi,np.pi)
 		z_data_corr = self._center(z_data,np.complex(xc,yc))
 		theta0, Ql, fr = self._phase_fit(f_data,z_data_corr,theta0,Ql,fr)
-		#print "Ql from phasefit is: " + str(Ql)
+		#print("Ql from phasefit is: " + str(Ql))
 		Qi = Ql/(1.-r0)
 		Qc = 1./(1./Ql-1./Qi)
 	
@@ -138,7 +138,7 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 				errors = {"Ql_err":Ql_err, "Qc_err":Qc_err, "fr_err":fr_err,"chi_square":chi_square,"Qi_err":Qi_err}
 				results.update( errors )
 			else:
-				print "WARNING: Error calculation failed!"
+				print("WARNING: Error calculation failed!")
 		else:
 			#just calc chisquared:
 			fun2 = lambda x: self._residuals_notch_ideal(x,f_data,z_data)**2
@@ -307,10 +307,10 @@ class notch_port(circlefit, save_load, plotting, calibration):
 			A2 = 0.
 		else:
 			A2 = 0.
-			print "WARNING: The ignoreslope option is ignored! Corrections to the baseline should be done manually prior to fitting."
-			print "see also: resonator_tools.calibration.fit_baseline_amp() etc. for help on fitting the baseline."
-			print "There is also an example ipython notebook for using this function."
-			print "However, make sure to understand the impact of the baseline (parasitic coupled resonances etc.) on your system."
+			print("WARNING: The ignoreslope option is ignored! Corrections to the baseline should be done manually prior to fitting.")
+			print("see also: resonator_tools.calibration.fit_baseline_amp() etc. for help on fitting the baseline.")
+			print("There is also an example ipython notebook for using this function.")
+			print("However, make sure to understand the impact of the baseline (parasitic coupled resonances etc.) on your system.")
 			#z_data = (np.absolute(z_data)-A2*(f_data-fr)) * np.exp(np.angle(z_data)*1j)  #usually not necessary
 		if delay is None:
 			if guess==True:
@@ -373,7 +373,7 @@ class notch_port(circlefit, save_load, plotting, calibration):
 		theta0 = self._periodic_boundary(phi0+np.pi,np.pi)
 		z_data_corr = self._center(z_data,np.complex(xc,yc))
 		theta0, Ql, fr = self._phase_fit(f_data,z_data_corr,theta0,Ql,fr)
-		#print "Ql from phasefit is: " + str(Ql)
+		#print("Ql from phasefit is: " + str(Ql))
 		absQc = Ql/(2.*r0)
 		complQc = absQc*np.exp(1j*((-1.)*phi0))
 		Qc = 1./(1./complQc).real	# here, taking the real part of (1/complQc) from diameter correction method
@@ -407,7 +407,7 @@ class notch_port(circlefit, save_load, plotting, calibration):
 				errors = {"phi0_err":phi0_err, "Ql_err":Ql_err, "absQc_err":absQc_err, "fr_err":fr_err,"chi_square":chi_square,"Qi_no_corr_err":Qi_no_corr_err,"Qi_dia_corr_err": Qi_dia_corr_err}
 				results.update( errors )
 			else:
-				print "WARNING: Error calculation failed!"
+				print("WARNING: Error calculation failed!")
 		else:
 			#just calc chisquared:
 			fun2 = lambda x: self._residuals_notch_ideal(x,f_data,z_data)**2

--- a/resonator_tools/circuit.py
+++ b/resonator_tools/circuit.py
@@ -595,7 +595,7 @@ class resonator(object):
 		self.port = {}
 		self.transm = {}
 		if len(ports) > 0:
-			for key, pname in ports.iteritems():
+			for key, pname in iter(ports.items()):
 				if pname=='direct':
 					self.port.update({key:reflection_port()})
 				elif pname=='notch':

--- a/resonator_tools/circuit.py
+++ b/resonator_tools/circuit.py
@@ -4,9 +4,9 @@ import scipy.optimize as spopt
 from scipy.constants import hbar
 from scipy.interpolate import splrep, splev
 
-from utilities import plotting, save_load, Watt2dBm, dBm2Watt
-from circlefit import circlefit
-from calibration import calibration
+from resonator_tools.utilities import plotting, save_load, Watt2dBm, dBm2Watt
+from resonator_tools.circlefit import circlefit
+from resonator_tools.calibration import calibration
 
 ##
 ## z_data_raw denotes the raw data

--- a/tests/resonator_tests.py
+++ b/tests/resonator_tests.py
@@ -2,10 +2,10 @@ from nose.tools import *
 import resonator
 
 def setup():
-    print "SETUP!"
+    print("SETUP!")
 
 def teardown():
-    print "TEAR DOWN!"
+    print("TEAR DOWN!")
 
 def test_basic():
-    print "I RAN!"
+    print("I RAN!")


### PR DESCRIPTION
Minor changes to make code compatibile with both Python 2 and Python 3.
- "print 'foo'" becomes "print('foo')
- relative imports no longer supported e.g. "from utilities import plotting" becomes "from resonator_tools.utilities import plotting"
- a couple of other minor changes

To maintain compatibility with old and new, please use _print() function_ and _absolute imports_ in future commits. You can also run code through the _2to3_ command line utility to locate incompatible commands.

Changes to matplotlib handling have not been included in this pull request as I cannot test backward compatibility. Some warnings may appear in matplotlib >=2.0 but plotting still behaves as expected.