### PR TITLE
Make compatible with numpy>=1.20

### DIFF
--- a/resonator_tools/circlefit.py
+++ b/resonator_tools/circlefit.py
@@ -18,7 +18,7 @@ class circlefit(object):
     
     def _dist(self,x):
         np.absolute(x,x)
-        c = (x > np.pi).astype(np.int)
+        c = (x > np.pi).astype(int)
         return x+c*(-2.*x+2.*np.pi)  
         
     def _periodic_boundary(self,x,bound):
@@ -64,10 +64,10 @@ class circlefit(object):
         Ql, fr = p_final[0]
         p0 = fr
         p_final = spopt.leastsq(lambda a,b,c: residuals_3(a,b,c,theta0,Ql),p0,args=(f_data,phase))#,ftol=1e-12,xtol=1e-12)
-        fr = p_final[0]
+        fr = p_final[0][0]
         p0 = Ql
         p_final = spopt.leastsq(lambda a,b,c: residuals_4(a,b,c,theta0,fr),p0,args=(f_data,phase))#,ftol=1e-12,xtol=1e-12)
-        Ql = p_final[0]
+        Ql = p_final[0][0]
         p0 = np.array([theta0, Ql, fr], dtype='float64') 
         p_final = spopt.leastsq(residuals_5,p0,args=(f_data,phase))
         return p_final[0]
@@ -205,10 +205,10 @@ class circlefit(object):
         '''
         def funcsqr(p,x):
             fr,absQc,Ql,phi0,delay,a,alpha = p
-            return np.array([np.absolute( ( a*np.exp(np.complex(0,alpha))*np.exp(np.complex(0,-2.*np.pi*delay*x[i])) * ( 1 - (Ql/absQc*np.exp(np.complex(0,phi0)))/(np.complex(1,2*Ql*(x[i]-fr)/fr)) )  ) )**2 for i in range(len(x))])
+            return np.array([np.absolute( ( a*np.exp(complex(0,alpha))*np.exp(complex(0,-2.*np.pi*delay*x[i])) * ( 1 - (Ql/absQc*np.exp(complex(0,phi0)))/(complex(1,2*Ql*(x[i]-fr)/fr)) )  ) )**2 for i in range(len(x))])
         def residuals(p,x,y):
             fr,absQc,Ql,phi0,delay,a,alpha = p
-            err = [np.absolute( y[i] - ( a*np.exp(np.complex(0,alpha))*np.exp(np.complex(0,-2.*np.pi*delay*x[i])) * ( 1 - (Ql/absQc*np.exp(np.complex(0,phi0)))/(np.complex(1,2*Ql*(x[i]-fr)/fr)) )  ) ) for i in range(len(x))]
+            err = [np.absolute( y[i] - ( a*np.exp(complex(0,alpha))*np.exp(complex(0,-2.*np.pi*delay*x[i])) * ( 1 - (Ql/absQc*np.exp(complex(0,phi0)))/(complex(1,2*Ql*(x[i]-fr)/fr)) )  ) ) for i in range(len(x))]
             return err
         p0 = [fr,absQc,Ql,phi0,delay,a,alpha]
         (popt, params_cov, infodict, errmsg, ier) = spopt.leastsq(residuals,p0,args=(np.array(f_data),np.array(z_data)),full_output=True,maxfev=maxiter)
@@ -224,14 +224,14 @@ class circlefit(object):
     
     def _optimizedelay(self,f_data,z_data,Ql,fr,maxiter=4):
         xc,yc,r0 = self._fit_circle(z_data)
-        z_data = self._center(z_data,np.complex(xc,yc))
+        z_data = self._center(z_data,complex(xc,yc))
         theta, Ql, fr, slope = self._phase_fit_wslope(f_data,z_data,0.,Ql,fr,0.)
         delay = 0.
         for i in range(maxiter-1): #interate to get besser phase delay term
             delay = delay - slope/(2.*2.*np.pi)
             z_data_corr = self._remove_cable_delay(f_data,z_data,delay)
             xc, yc, r0 = self._fit_circle(z_data_corr)
-            z_data_corr2 = self._center(z_data_corr,np.complex(xc,yc))
+            z_data_corr2 = self._center(z_data_corr,complex(xc,yc))
             theta0, Ql, fr, slope = self._phase_fit_wslope(f_data,z_data_corr2,0.,Ql,fr,0.)
         delay = delay - slope/(2.*2.*np.pi)  #start final interation
         return delay
@@ -300,15 +300,15 @@ class circlefit(object):
     
     def _residuals_notch_full(self,p,x,y):
         fr,absQc,Ql,phi0,delay,a,alpha = p
-        err = np.absolute( y - ( a*np.exp(np.complex(0,alpha))*np.exp(np.complex(0,-2.*np.pi*delay*x)) * ( 1 - (Ql/absQc*np.exp(np.complex(0,phi0)))/(np.complex(1,2*Ql*(x-fr)/float(fr))) )  ) )
+        err = np.absolute( y - ( a*np.exp(complex(0,alpha))*np.exp(complex(0,-2.*np.pi*delay*x)) * ( 1 - (Ql/absQc*np.exp(complex(0,phi0)))/(complex(1,2*Ql*(x-fr)/float(fr))) )  ) )
         return err
     
     def _residuals_notch_ideal(self,p,x,y):
         fr,absQc,Ql,phi0 = p
         #if fr == 0: print(p)
         err = np.absolute( y - (  ( 1. - (Ql/float(absQc)*np.exp(1j*phi0))/(1+2j*Ql*(x-fr)/float(fr)) )  ) )
-        #if np.isinf((np.complex(1,2*Ql*(x-fr)/float(fr))).imag):
-         #   print(np.complex(1,2*Ql*(x-fr)/float(fr)))
+        #if np.isinf((complex(1,2*Ql*(x-fr)/float(fr))).imag):
+         #   print(complex(1,2*Ql*(x-fr)/float(fr)))
           #  print("x: " + str(x))
            # print("Ql: " +str(Ql))
             #print("fr: " +str(fr))
@@ -318,8 +318,8 @@ class circlefit(object):
         fr,absQc,Ql,phi0 = p
         #if fr == 0: print(p)
         err = y - (  ( 1. - (Ql/float(absQc)*np.exp(1j*phi0))/(1+2j*Ql*(x-fr)/float(fr)) )  )
-        #if np.isinf((np.complex(1,2*Ql*(x-fr)/float(fr))).imag):
-         #   print(np.complex(1,2*Ql*(x-fr)/float(fr)))
+        #if np.isinf((complex(1,2*Ql*(x-fr)/float(fr))).imag):
+         #   print(complex(1,2*Ql*(x-fr)/float(fr)))
           #  print("x: " + str(x))
            # print("Ql: " +str(Ql))
             #print("fr: " +str(fr))
@@ -329,8 +329,8 @@ class circlefit(object):
         fr,Qc,Ql = p
         #if fr == 0: print(p)
         err = y - ( 2.*Ql/Qc - 1. + 2j*Ql*(fr-x)/fr ) / ( 1. - 2j*Ql*(fr-x)/fr )
-        #if np.isinf((np.complex(1,2*Ql*(x-fr)/float(fr))).imag):
-         #   print(np.complex(1,2*Ql*(x-fr)/float(fr)))
+        #if np.isinf((complex(1,2*Ql*(x-fr)/float(fr))).imag):
+         #   print(complex(1,2*Ql*(x-fr)/float(fr)))
           #  print("x: " + str(x))
            # print("Ql: " +str(Ql))
             #print("fr: " +str(fr))
@@ -338,7 +338,7 @@ class circlefit(object):
     
     def _residuals_transm_ideal(self,p,x,y):
         fr,Ql = p
-        err = np.absolute( y -   ( 1./(np.complex(1,2*Ql*(x-fr)/float(fr))) )   )
+        err = np.absolute( y -   ( 1./(complex(1,2*Ql*(x-fr)/float(fr))) )   )
         return err
     
     

--- a/resonator_tools/circuit.py
+++ b/resonator_tools/circuit.py
@@ -86,11 +86,11 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 		delay, params = self.get_delay(f_data,z_data,ignoreslope=ignoreslope,guess=guessdelay,delay=fixed_delay)
 		z_data = (z_data-params[1]*(f_data-params[4]))*np.exp(2.*1j*np.pi*delay*f_data)
 		xc, yc, r0 = self._fit_circle(z_data)
-		zc = np.complex(xc,yc)
+		zc = complex(xc,yc)
 		fitparams = self._phase_fit(f_data,self._center(z_data,zc),0.,np.absolute(params[5]),params[4])
 		theta, Ql, fr = fitparams
 		beta = self._periodic_boundary(theta+np.pi,np.pi) ###
-		offrespoint = np.complex((xc+r0*np.cos(beta)),(yc+r0*np.sin(beta)))
+		offrespoint = complex((xc+r0*np.cos(beta)),(yc+r0*np.sin(beta)))
 		alpha = self._periodic_boundary(np.angle(offrespoint)+np.pi,np.pi)
 		#a = np.absolute(offrespoint)
 		#alpha = np.angle(zc)
@@ -113,7 +113,7 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 		xc, yc, r0 = self._fit_circle(z_data,refine_results=refine_results)
 		phi0 = -np.arcsin(yc/r0)
 		theta0 = self._periodic_boundary(phi0+np.pi,np.pi)
-		z_data_corr = self._center(z_data,np.complex(xc,yc))
+		z_data_corr = self._center(z_data,complex(xc,yc))
 		theta0, Ql, fr = self._phase_fit(f_data,z_data_corr,theta0,Ql,fr)
 		#print("Ql from phasefit is: " + str(Ql))
 		Qi = Ql/(1.-r0)
@@ -239,7 +239,7 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 		'''
 		full model for notch type resonances
 		'''
-		return a*np.exp(np.complex(0,alpha))*np.exp(-2j*np.pi*f*delay) * ( 2.*Ql/Qc - 1. + 2j*Ql*(fr-f)/fr ) / ( 1. - 2j*Ql*(fr-f)/fr )	   
+		return a*np.exp(complex(0,alpha))*np.exp(-2j*np.pi*f*delay) * ( 2.*Ql/Qc - 1. + 2j*Ql*(fr-f)/fr ) / ( 1. - 2j*Ql*(fr-f)/fr )	   
 		
 	def get_single_photon_limit(self,unit='dBm'):
 		'''
@@ -331,13 +331,13 @@ class notch_port(circlefit, save_load, plotting, calibration):
 		delay, params = self.get_delay(f_data,z_data,ignoreslope=ignoreslope,guess=guessdelay,delay=fixed_delay)
 		z_data = (z_data-params[1]*(f_data-params[4]))*np.exp(2.*1j*np.pi*delay*f_data)
 		xc, yc, r0 = self._fit_circle(z_data)
-		zc = np.complex(xc,yc)
+		zc = complex(xc,yc)
 		if Ql_guess is None: Ql_guess=np.absolute(params[5]) 
 		if fr_guess is None: fr_guess=params[4] 
 		fitparams = self._phase_fit(f_data,self._center(z_data,zc),0.,Ql_guess,fr_guess) 
 		theta, Ql, fr = fitparams
 		beta = self._periodic_boundary(theta+np.pi,np.pi)
-		offrespoint = np.complex((xc+r0*np.cos(beta)),(yc+r0*np.sin(beta)))
+		offrespoint = complex((xc+r0*np.cos(beta)),(yc+r0*np.sin(beta)))
 		alpha = np.angle(offrespoint)
 		a = np.absolute(offrespoint)
 		return delay, a, alpha, fr, Ql, params[1], params[4]
@@ -373,7 +373,7 @@ class notch_port(circlefit, save_load, plotting, calibration):
 		xc, yc, r0 = self._fit_circle(z_data,refine_results=refine_results)
 		phi0 = -np.arcsin(yc/r0)
 		theta0 = self._periodic_boundary(phi0+np.pi,np.pi)
-		z_data_corr = self._center(z_data,np.complex(xc,yc))
+		z_data_corr = self._center(z_data,complex(xc,yc))
 		theta0, Ql, fr = self._phase_fit(f_data,z_data_corr,theta0,Ql,fr)
 		#print("Ql from phasefit is: " + str(Ql))
 		absQc = Ql/(2.*r0)
@@ -509,7 +509,7 @@ class notch_port(circlefit, save_load, plotting, calibration):
 		'''
 		full model for notch type resonances
 		'''
-		return a*np.exp(np.complex(0,alpha))*np.exp(-2j*np.pi*f*delay)*(1.-Ql/Qc*np.exp(1j*phi)/(1.+2j*Ql*(f-fr)/fr))	 
+		return a*np.exp(complex(0,alpha))*np.exp(-2j*np.pi*f*delay)*(1.-Ql/Qc*np.exp(1j*phi)/(1.+2j*Ql*(f-fr)/fr))	 
 	
 	def get_single_photon_limit(self,unit='dBm',diacorr=True):
 		'''

--- a/resonator_tools/utilities.py
+++ b/resonator_tools/utilities.py
@@ -147,20 +147,20 @@ class save_load(object):
 				if ((line!="\n") and (line[0]!="#") and (line[0]!="!")) :
 					lineinfo = line.split(delimiter)
 					f_data.append(float(lineinfo[0])*fdata_unit)
-					z_data_raw.append(np.complex(float(lineinfo[y1_col]),float(lineinfo[y2_col])))
+					z_data_raw.append(complex(float(lineinfo[y1_col]),float(lineinfo[y2_col])))
 		elif dtype=='linmagphaserad' or dtype=='linmagphasedeg':
 			for line in lines:
 				if ((line!="\n") and (line[0]!="#") and (line[0]!="!") and (line[0]!="M") and (line[0]!="P")):
 					lineinfo = line.split(delimiter)
 					f_data.append(float(lineinfo[0])*fdata_unit)
-					z_data_raw.append(float(lineinfo[y1_col])*np.exp( np.complex(0.,phase_conversion*float(lineinfo[y2_col]))))
+					z_data_raw.append(float(lineinfo[y1_col])*np.exp( complex(0.,phase_conversion*float(lineinfo[y2_col]))))
 		elif dtype=='dBmagphaserad' or dtype=='dBmagphasedeg':
 			for line in lines:
 				if ((line!="\n") and (line[0]!="#") and (line[0]!="!") and (line[0]!="M") and (line[0]!="P")):
 					lineinfo = line.split(delimiter)
 					f_data.append(float(lineinfo[0])*fdata_unit)
 					linamp = 10**(float(lineinfo[y1_col])/20.)
-					z_data_raw.append(linamp*np.exp( np.complex(0.,phase_conversion*float(lineinfo[y2_col]))))
+					z_data_raw.append(linamp*np.exp( complex(0.,phase_conversion*float(lineinfo[y2_col]))))
 		else:
 			warnings.warn("Undefined input type! Use 'realimag', 'dBmagphaserad', 'linmagphaserad', 'dBmagphasedeg' or 'linmagphasedeg'.", SyntaxWarning)
 		self.f_data = np.array(f_data)


### PR DESCRIPTION
This merge replaces `np.int` and `np.complex` with `int` and `complex` respectively since these are [deprecated in numpy >= 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations). These replacements should be safe since the numpy versions were just aliases to the built-in types.

Also fixes a minor issue where numpy would complain about inhomogeneous array dimensions in `circlefit.py`, line 71.

Fits of notch resonators work for me using this branch, and `example/notch_port_example.py` and `example/reflection_port_example.py` run as well.

Tested using

- python=3.11.5
- numpy==1.24.3
- scipy==1.10.1
