### PR TITLE
axisbg changed to facecolor for plt.axes() function calls

### DIFF
--- a/resonator_tools/circuit.py
+++ b/resonator_tools/circuit.py
@@ -470,9 +470,9 @@ class notch_port(circlefit, save_load, plotting, calibration):
 		Qc_ann = ax3.annotate('Qc = %e +- %e' % (self.fitresults['absQc'],self.fitresults['absQc_err']),xy=(0.1, 0.4), xycoords='axes fraction')
 		Qi_ann = ax3.annotate('Qi = %e +- %e' % (self.fitresults['Qi_dia_corr'],self.fitresults['Qi_dia_corr_err']),xy=(0.1, 0.2), xycoords='axes fraction')
 		axcolor = 'lightgoldenrodyellow'
-		axdelay = plt.axes([0.25, 0.05, 0.65, 0.03], axisbg=axcolor)
-		axf2 = plt.axes([0.25, 0.1, 0.65, 0.03], axisbg=axcolor)
-		axf1 = plt.axes([0.25, 0.15, 0.65, 0.03], axisbg=axcolor)
+		axdelay = plt.axes([0.25, 0.05, 0.65, 0.03], facecolor=axcolor)
+		axf2 = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
+		axf1 = plt.axes([0.25, 0.15, 0.65, 0.03], facecolor=axcolor)
 		sscale = 10.
 		sdelay = Slider(axdelay, 'delay', -1., 1., valinit=self.__delay/(sscale*self.__delay),valfmt='%f')
 		df = (fmax-fmin)*0.05


### PR DESCRIPTION
Currently GUIfit is broken for all recent versions of matplotlib because axisbg was depreciated in matplotlib 2.0.0 (2017) for facecolor:

https://matplotlib.org/3.4.3/api/prev_api_changes/api_changes_2.0.0.html