### PR TITLE
_S11_directrefl modificaiton

### DIFF
--- a/resonator_tools/circuit.py
+++ b/resonator_tools/circuit.py
@@ -239,7 +239,7 @@ class reflection_port(circlefit, save_load, plotting, calibration):
 		'''
 		full model for notch type resonances
 		'''
-		return a*np.exp(complex(0,alpha))*np.exp(-2j*np.pi*f*delay) * ( 2.*Ql/Qc - 1. + 2j*Ql*(fr-f)/fr ) / ( 1. - 2j*Ql*(fr-f)/fr )	   
+		return a*np.exp(complex(0,alpha))*np.exp(-2j*np.pi*f*delay) * (Ql/Qc - 1. + 2j*Ql*(fr-f)/fr ) / ( 1. - 2j*Ql*(fr-f)/fr )
 		
 	def get_single_photon_limit(self,unit='dBm'):
 		'''


### PR DESCRIPTION
I think there is a mismatch between equation 1 of _Efficient and robust analysis of complex scattering data under noise in microwave resonators_ and the definition of the reflection parameter _S11_directrefl. I think 2Ql/Qc should be replaced by Ql/Qc.