### PR TITLE
Edited 'get_photons_in_resonator' method in circuit.py

### DIFF
--- a/resonator_tools/circuit.py
+++ b/resonator_tools/circuit.py
@@ -480,7 +480,7 @@ class reflection_port(circlefit, save_load, plotting, calibration):
             fr = self.fitresults["fr"]
             k_c = 2 * np.pi * fr / self.fitresults["Qc"]
             k_i = 2 * np.pi * fr / self.fitresults["Qi"]
-            return 4.0 * k_c / (2.0 * np.pi * hbar * fr * (k_c + k_i) ** 2) * power
+            return 2.0 * k_c / (2.0 * np.pi * hbar * fr * (k_c + k_i) ** 2) * power
         else:
             warnings.warn("Please perform the fit first", UserWarning)
             return None


### PR DESCRIPTION
I think there is a little misprint in the final formula for photons number in resonator, instead of multiplying the whole formual by 4 it should be 2. I compared it with several works, e.g. "Materials loss measurements using superconducting microwave resonators" (page 13, equation (20)), "Noise and loss of superconducting aluminium resonators at single photon energies" (page 2, equation (1))